### PR TITLE
Update to stable release 28 and replace gtk-3.0 with gtk-3.20

### DIFF
--- a/org.gtk.Gtk3theme.Yaru.json
+++ b/org.gtk.Gtk3theme.Yaru.json
@@ -68,13 +68,12 @@
         },
         {
             "type": "shell",
-            "//": "Replace gtk-3.0 folder with gtk-3.20",
+            "//": "Rename gtk-3.20 folder as gtk-3.0, and modify meson.build accordingly",
             "commands": [
+              "sed -i -e \"s/subdir('gtk-3.20')//\" gtk/src/light/meson.build",
               "sed -i -e \"s/gtk-3.20/gtk-3.0/\" gtk/src/light/gtk-3.20/meson.build",
-              "cat gtk/src/light/gtk-3.20/meson.build",
               "rm -r gtk/src/light/gtk-3.0",
-              "mv gtk/src/light/gtk-3.20 gtk/src/light/gtk-3.0",
-              "sed -i -e \"s/subdir('gtk-3.20')//\" gtk/src/light/meson.build"
+              "mv gtk/src/light/gtk-3.20 gtk/src/light/gtk-3.0"
           ]
         }
       ]

--- a/org.gtk.Gtk3theme.Yaru.json
+++ b/org.gtk.Gtk3theme.Yaru.json
@@ -57,13 +57,24 @@
         {
           "type": "git",
           "url": "https://github.com/ubuntu/yaru.git",
-          "commit": "5944aae75b448837da7032e6801848c514d9655a"
+          "commit": "r28"
         },
         {
           "type": "shell",
           "//": "Disable building everything not used",
           "commands": [
             "sed -i -e \"s/subdir('icons')//\" -e \"s/subdir('sounds')//\" -e \"s/subdir('gnome-shell')//\" -e \"s/subdir('sessions')//\" meson.build"
+          ]
+        },
+        {
+            "type": "shell",
+            "//": "Replace gtk-3.0 folder with gtk-3.20",
+            "commands": [
+              "sed -i -e \"s/gtk-3.20/gtk-3.0/\" gtk/src/light/gtk-3.20/meson.build",
+              "cat gtk/src/light/gtk-3.20/meson.build",
+              "rm -r gtk/src/light/gtk-3.0",
+              "mv gtk/src/light/gtk-3.20 gtk/src/light/gtk-3.0",
+              "sed -i -e \"s/subdir('gtk-3.20')//\" gtk/src/light/meson.build"
           ]
         }
       ]


### PR DESCRIPTION
Previous release r18 used folder gtk-3.0, while the new r28 splitted the
support in gtk-3.0 and gtk-3.20. I could not find (yet) a way to simply
use the new folder location, so I added a script to replace the content
of folder gtk-3.0 with the content in gtk-3.20.

Unless flatpak theming requires the folder to be named gtk-3.0, this
would be a temporary workaround