### PR TITLE
Upgrade to 21.04

### DIFF
--- a/org.gtk.Gtk3theme.Yaru.json
+++ b/org.gtk.Gtk3theme.Yaru.json
@@ -66,8 +66,7 @@
           "commands": [
             "rm -r gtk/src/default/gtk-3.0",
             "mv gtk/src/default/gtk-3.20 gtk/src/default/gtk-3.0",
-            "sed -i -e \"s/  '3.0,'/  '3.0'/\" gtk/src/meson.build",
-            "sed -i -e \"s/  '3.20'//\" gtk/src/meson.build"
+            "sed -i -e \"/^  '3.20',/d\" gtk/src/meson.build"
           ]
         }
       ]

--- a/org.gtk.Gtk3theme.Yaru.json
+++ b/org.gtk.Gtk3theme.Yaru.json
@@ -58,7 +58,7 @@
         {
           "type": "git",
           "url": "https://github.com/ubuntu/yaru.git",
-          "tag": "20.10.4"
+          "tag": "21.04.1"
         },
         {
           "type": "shell",


### PR DESCRIPTION
I saw that Yaru has changes between 20.10 and 21.04 (which includes support for GTK4) so I wanted to try to update the package so it reflects that.

Closes #10.

(note that this is my first time contributing anywhere so please be kind)