### PR TITLE
update to yaru-theme-21.10.2

### DIFF
--- a/org.gtk.Gtk3theme.Yaru.json
+++ b/org.gtk.Gtk3theme.Yaru.json
@@ -2,7 +2,7 @@
   "id": "org.gtk.Gtk3theme.Yaru",
   "branch": "3.22",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "20.08",
+  "runtime-version": "21.08",
   "sdk": "org.freedesktop.Sdk",
   "build-extension": true,
   "appstream-compose": false,
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/sass/sassc/archive/3.5.0.tar.gz",
-          "sha256": "26f54e31924b83dd706bc77df5f8f5553a84d51365f0e3c566df8de027918042"
+          "url": "https://github.com/sass/sassc/archive/3.6.2.tar.gz",
+          "sha256": "608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03"
         },
         {
           "type": "script",
@@ -34,8 +34,8 @@
           "sources": [
             {
               "type": "archive",
-              "url": "https://github.com/sass/libsass/archive/3.5.4.tar.gz",
-              "sha256": "5f61cbcddaf8e6ef7a725fcfa5d05297becd7843960f245197ebb655ff868770"
+              "url": "https://github.com/sass/libsass/archive/3.6.5.tar.gz",
+              "sha256": "89d8f2c46ae2b1b826b58ce7dde966a176bac41975b82e84ad46b01a55080582"
             },
             {
               "type": "script",
@@ -52,13 +52,13 @@
       "build-options": {
         "prefix": "/usr/share/runtime",
         "append-path": "/usr/share/runtime/share/themes/Yaru/gtk-3.0/bin",
-        "config-opts": [ "-Dicons=false", "-Dgnome-shell=false", "-Dsounds=false", "-Dsessions=false", "-Ddark=false", "-Dlight=false"  ]
+        "config-opts": [ "-Dicons=false", "-Dgnome-shell=false", "-Dsounds=false", "-Dsessions=false", "-Ddark=false", "-Dgtksourceview=false", "-Dmetacity=false"  ]
       },
       "sources": [
         {
           "type": "git",
           "url": "https://github.com/ubuntu/yaru.git",
-          "tag": "21.04.1"
+          "tag": "21.10.2"
         },
         {
           "type": "shell",


### PR DESCRIPTION
### changes in PR:

- use newer archives of sassc and libsass
- move to runtime-version: 21.08
- make metacity and gtksourceview options as false and remove light option
